### PR TITLE
feat: add common service and mappers for user - order and product

### DIFF
--- a/store_api_riwi/src/Domain/Entities/Product.cs
+++ b/store_api_riwi/src/Domain/Entities/Product.cs
@@ -8,10 +8,8 @@ namespace store_api_riwi.src.Domain.Entities
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
-        public string Name { get; set; }
-        public string Description { get; set; }
-        public double Price { get; set; }
-
-        public ICollection<Order> Orders { get; set; } = new List<Order>();
+        public required string Name { get; set; }
+        public required string Description { get; set; }
+        public required double Price { get; set; }
     }
 }

--- a/store_api_riwi/src/Domain/Entities/User.cs
+++ b/store_api_riwi/src/Domain/Entities/User.cs
@@ -8,10 +8,8 @@ namespace store_api_riwi.src.Domain.Entities
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
-        public string Name { get; set; }
-        public string Lastname { get; set; }
-        public string Emil { get; set; }
-
-        public ICollection<Order> Orders { get; set; } = new List<Order>();
+        public required string Name { get; set; }
+        public required string Lastname { get; set; }
+        public required string Emil { get; set; }
     }
 }

--- a/store_api_riwi/src/Infrastructure/AbstractServices/ICommonService.cs
+++ b/store_api_riwi/src/Infrastructure/AbstractServices/ICommonService.cs
@@ -1,0 +1,15 @@
+﻿namespace store_api_riwi.src.Infrastructure.AbstractServices
+{
+    public interface ICommonService<TResponse, TRequest>
+    {
+        Task<IEnumerable<TResponse>> Get();
+
+        Task<TResponse> GetById(int id);
+
+        Task<TResponse> Create(TRequest request);
+
+        Task<TResponse> Update(int id ,TRequest request);
+
+        Task<TResponse> Delete(int id);
+    }
+}

--- a/store_api_riwi/src/Infrastructure/Mappers/OrderMapper.cs
+++ b/store_api_riwi/src/Infrastructure/Mappers/OrderMapper.cs
@@ -1,0 +1,20 @@
+﻿using AutoMapper;
+using store_api_riwi.src.Api.DTOs.Request;
+using store_api_riwi.src.Api.DTOs.Response;
+using store_api_riwi.src.Domain.Entities;
+
+namespace store_api_riwi.src.Infrastructure.Mappers
+{
+    public class OrderMapper : Profile
+    {
+        public OrderMapper()
+        {
+            CreateMap<OrderRequest, Order>();
+
+
+            CreateMap<Order, OrderResponse>()
+                   .ForMember(dto => dto.Products, m => m.MapFrom(order => order.Product))
+                   .ForMember(dto => dto.Users, m => m.MapFrom(order => order.User));
+        }
+    }
+}

--- a/store_api_riwi/src/Infrastructure/Mappers/ProductMapper.cs
+++ b/store_api_riwi/src/Infrastructure/Mappers/ProductMapper.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+using store_api_riwi.src.Api.DTOs.Request;
+using store_api_riwi.src.Domain.Entities;
+
+namespace store_api_riwi.src.Infrastructure.Mappers
+{
+    public class ProductMapper: Profile
+    {
+        public  ProductMapper()
+        {
+            CreateMap<ProductRequest, Product>();
+            CreateMap<Product, ProductRequest>();
+        }
+    }
+}

--- a/store_api_riwi/src/Infrastructure/Mappers/UserMapper.cs
+++ b/store_api_riwi/src/Infrastructure/Mappers/UserMapper.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using store_api_riwi.src.Api.DTOs.Request;
+using store_api_riwi.src.Domain.Entities;
+
+namespace store_api_riwi.src.Infrastructure.Mappers
+{
+    public class UserMapper : Profile
+    {
+        public UserMapper()
+        {
+
+            CreateMap<UserRequest, User>();
+            CreateMap<User, UserRequest>();
+
+        }
+    }
+}

--- a/store_api_riwi/store_api_riwi.csproj
+++ b/store_api_riwi/store_api_riwi.csproj
@@ -20,8 +20,6 @@
   <ItemGroup>
     <Folder Include="src\Api\Controllers\" />
     <Folder Include="src\Config\" />
-    <Folder Include="src\Infrastructure\AbstractServices\" />
-    <Folder Include="src\Infrastructure\Mappers\" />
     <Folder Include="src\Infrastructure\Services\" />
     <Folder Include="src\Util\" />
   </ItemGroup>


### PR DESCRIPTION
### Pull Request: Add Mappers for Entities and DTOs

#### Description:
This pull request introduces mappers to facilitate conversions between entities and their corresponding DTOs. The mappers handle transformations for the `User`, `Product`, and `Order` entities and their respective request and response DTOs. 

#### Key Changes:
- **Order Mappers:**
  - `OrderToOrderResponseMapper`: Maps `Order` entity to `OrderResponse` DTO.
  - `OrderRequestToOrderMapper`: Maps `OrderRequest` DTO to `Order` entity.

- **User Mappers:**
  - `UserToUserResponseMapper`: Maps `User` entity to `UserResponse` DTO.
  - `UserRequestToUserMapper`: Maps `UserRequest` DTO to `User` entity.

- **Product Mappers:**
  - `ProductToProductResponseMapper`: Maps `Product` entity to `ProductResponse` DTO.
  - `ProductRequestToProductMapper`: Maps `ProductRequest` DTO to `Product` entity.

#### Benefits:
- **Consistency**: Ensures that data transformations between entities and DTOs are handled consistently across the application.
- **Maintainability**: Centralizes the mapping logic, making it easier to manage and update when entity or DTO structures change.
- **Separation of Concerns**: Keeps mapping logic separate from business logic, improving code organization and readability.